### PR TITLE
add worldthreader support

### DIFF
--- a/common/src/main/java/net/conczin/immersive_optimization/TickScheduler.java
+++ b/common/src/main/java/net/conczin/immersive_optimization/TickScheduler.java
@@ -61,7 +61,7 @@ public class TickScheduler {
             while (server.isRunning()) {
                 try {
                     // Tick levels
-                    for (ServerLevel level : server.getAllLevels()) {
+                    for (ServerLevel level : scheduler.knownLevels.values()) {
                         scheduler.tickLevel(level);
                     }
 
@@ -129,6 +129,7 @@ public class TickScheduler {
     }
 
     public final Map<Identifier, LevelData> levelData = new ConcurrentHashMap<>();
+    public final Map<Identifier, ServerLevel> knownLevels = new ConcurrentHashMap<>();
 
     @Nullable
     public LevelData getLevelData(Level level) {
@@ -137,10 +138,13 @@ public class TickScheduler {
 
     public void reset() {
         levelData.clear();
+        knownLevels.clear();
         frustum = null;
     }
 
     public void startLevelTick(ServerLevel level) {
+        knownLevels.put(level.dimension().identifier(), level);
+
         LevelData data = getLevelData(level);
         if (data == null) return;
 


### PR DESCRIPTION
## Summary
- stop iterating `server.getAllLevels()` from the Immersive Optimization worker thread
- maintain a concurrent `knownLevels` cache updated from `startLevelTick` (world-thread path)
- iterate cached levels from the worker thread and clear cache on reset

## Why
WorldThreader guards world-access APIs so non-world threads cannot request exclusive world access during ticking. The prior worker-thread call to `server.getAllLevels()` can trip that guard and spam:

`IllegalStateException: Only world threads may request exclusive access during world ticking!`

## Result
The worker no longer calls guarded server-level enumeration APIs off-thread, preventing WorldThreader access violations.
